### PR TITLE
feat(*): Add hot reload support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
-FROM golang:latest as builder
+FROM golang:1.22-alpine3.18
+
+# disable cgo to avoid gcc requirement bug
+ENV CGO_ENABLED=0
+
+# Fix entr watch on Mac/Windows
+ENV ENTR_INOTIFY_WORKAROUND 1
+
+RUN apk --no-cache add entr ca-certificates
 
 WORKDIR /app
 
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./cmd/server
-
-FROM alpine:latest
-
-RUN apk --no-cache add ca-certificates
-
-WORKDIR /root/
-
-COPY --from=builder /app/main .
-
 EXPOSE 8080
 
-CMD ["./main"]
+CMD ["./bin/boot-dev.sh"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # rinha-de-backend-2024q1
 
 
-```sh
-# Desenvolvimento local
-## Suba o banco de dados
-docker-compose up -d db
+## Development Mode
 
-## Suba o servidor
-go build -o main ./cmd/server
-DB_HOSTNAME=postgres://admin:123@localhost/rinha ./main
+There is a resource limitation as part of the tests (see [Rinha de Backend - 2024/Q1 / Restrições de CPU/Memória](https://github.com/zanfranceschi/rinha-de-backend-2024-q1?tab=readme-ov-file#restri%C3%A7%C3%B5es-de-cpumem%C3%B3ria)).
+
+So, in development mode, we're overwriting the limits to be able to have hot-reload on:
+```sh
+docker-compose -f docker-compose.yml -f docker-compose-dev.yml up db api01
 ```

--- a/bin/boot-dev.sh
+++ b/bin/boot-dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# autowatch and run tests
+find . | entr -nr go test $(go list ./...) &
+
+# autowatch and run server
+find . | entr -nr go run cmd/server/*.go

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	server := NewServer(dbpool)
 
-	fmt.Println(fmt.Sprintf("Server running on port %s", port))
+	fmt.Printf("Server running on port %s\n", port)
 
 	router := routing.New()
 	router.Get("/clientes/<id>/extrato", server.StatementHandler)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,10 @@
+---
+version: "3.5"
+
+services:
+  api01:
+    deploy:
+      resources:
+        limits:
+          cpus: 4
+          memory: "8192M"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
     build:
         context: .
         dockerfile: Dockerfile
+    volumes:
+      - .:/app:cached
+      - ./go.mod:/app/go.mod
+      - ./go.sum:/app/go.sum
+      # cache dependencies
+      - api:/go/pkg/mod
     hostname: api01
     environment:
       - DB_HOSTNAME=postgres://admin:123@localhost/rinha
@@ -25,7 +31,6 @@ services:
     environment:
       - DB_HOSTNAME=postgres://admin:123@localhost/rinha
       - PORT=8081
-
 
   nginx:
     image: nginx:latest
@@ -58,3 +63,6 @@ services:
         limits:
           cpus: "1"
           memory: "300MB"
+
+volumes:
+  api:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lmtani/rinha-2024-q1-code
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/goccy/go-json v0.10.2


### PR DESCRIPTION
## Descrição

Atualmente, se a gente faz qualquer mudança na API, temos que rebuildar o container porque a compilação do binário é parte dos steps do Dockerfile. A ideia aqui é deixar mais simples o desenvolvimento, habilitando a possibilidade de hot-reload.

Como temos uma limitação de recursos, foi criado um `docker-compose-dev.yml` para sobrescrever os limites em desenvolvimento.

## Exemplo

API rodando via `docker-compose`:
```sh
~> dc -f docker-compose.yml -f docker-compose-dev.yml up db api01
[+] Running 2/2
 ✔ Container rinha-2024-q1-code-db-1     Running                                                                                                                                                              0.0s 
 ✔ Container rinha-2024-q1-code-api01-1  Recreated                                                                                                                                                            0.1s 
Attaching to api01-1, db-1
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/cmd/server	[no test files]
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/internal/models	[no test files]
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/internal/repositories	[no test files]
api01-1  | ok  	github.com/lmtani/rinha-2024-q1-code/internal/services	0.001s
api01-1  | entr: broken inotify workaround enabled
api01-1  | Server running on port 8080
```

Simulando uma mudança na API:
```diff
diff --git a/cmd/server/main.go b/cmd/server/main.go
index ec1a7c7..c4ff169 100644
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,7 +39,7 @@ func main() {
 
        server := NewServer(dbpool)
 
-       fmt.Printf("Server running on port %s\n", port)
+       fmt.Printf("~> Server running on port %s\n", port)
 
        router := routing.New()
        router.Get("/clientes/<id>/extrato", server.StatementHandler)
```

Assim que o arquivo é salvo, podemos ver a API sendo recompilada, os testes rodando e subindo novamente:
```sh
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/cmd/server	[no test files]
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/internal/models	[no test files]
api01-1  | ?   	github.com/lmtani/rinha-2024-q1-code/internal/repositories	[no test files]
api01-1  | ok  	github.com/lmtani/rinha-2024-q1-code/internal/services	0.001s
api01-1  | ~> Server running on port 8080
```

